### PR TITLE
Migrate to cap-go/capacitor-social-login and fix session validation

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation project(':capacitor-preferences')
     implementation project(':capacitor-share')
     implementation project(':capacitor-status-bar')
+    implementation project(':capgo-capacitor-social-login')
     implementation project(':codetrix-studio-capacitor-google-auth')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -41,5 +41,8 @@ project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/sh
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
 
+include ':capgo-capacitor-social-login'
+project(':capgo-capacitor-social-login').projectDir = new File('../node_modules/@capgo/capacitor-social-login/android')
+
 include ':codetrix-studio-capacitor-google-auth'
 project(':codetrix-studio-capacitor-google-auth').projectDir = new File('../node_modules/@codetrix-studio/capacitor-google-auth/android')

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -24,6 +24,7 @@ def capacitor_pods
   pod 'CapacitorPreferences', :path => '../../node_modules/@capacitor/preferences'
   pod 'CapacitorShare', :path => '../../node_modules/@capacitor/share'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
+  pod 'CapgoCapacitorSocialLogin', :path => '../../node_modules/@capgo/capacitor-social-login'
   pod 'CodetrixStudioCapacitorGoogleAuth', :path => '../../node_modules/@codetrix-studio/capacitor-google-auth'
 end
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@capacitor/preferences": "^6.0.1",
         "@capacitor/share": "^6.0.2",
         "@capacitor/status-bar": "^6.0.0",
+        "@capgo/capacitor-social-login": "^0.0.42",
         "@codetrix-studio/capacitor-google-auth": "^3.4.0-rc.4",
         "@ionic/pwa-elements": "^3.3.0",
         "@ionic/vue": "^8.0.0",
@@ -2001,6 +2002,14 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-6.0.0.tgz",
       "integrity": "sha512-Wo0ILugYlmENegKDgTzVCPjbvP8h1ObgHslLdgeVG643ViMS/diausHIq8e104WIKCXtKIELmQeYVp9mX7932g==",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@capgo/capacitor-social-login": {
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@capgo/capacitor-social-login/-/capacitor-social-login-0.0.42.tgz",
+      "integrity": "sha512-gTY8CLX1MN8nxqp2EPrLW2qTDGtF/4QJwpR4eC/98PDR6yW0TN6QLHibMzE2IBEUJv+OA+Gw6cQnzfrNlGejPA==",
       "peerDependencies": {
         "@capacitor/core": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@capacitor/preferences": "^6.0.1",
     "@capacitor/share": "^6.0.2",
     "@capacitor/status-bar": "^6.0.0",
+    "@capgo/capacitor-social-login": "^0.0.42",
     "@codetrix-studio/capacitor-google-auth": "^3.4.0-rc.4",
     "@ionic/pwa-elements": "^3.3.0",
     "@ionic/vue": "^8.0.0",

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -29,13 +29,25 @@ export const useAuthStore = defineStore('auth', () => {
     await Preferences.set({
       key: 'access_token',
       value: token
-    })
+    });
+
+    // Store in memory
+    bearerToken.value = token;
+
+    // Validate session
+    await validateToken()
   }
 
   const removeBearerToken = async () => {
     await Preferences.remove({
       key: 'access_token'
-    })
+    });
+
+    // Remove token from memory
+    bearerToken.value = "";
+
+    // Remove user state
+    user.value = null;
   }
 
   const validateToken = async () => {
@@ -50,7 +62,6 @@ export const useAuthStore = defineStore('auth', () => {
         throw new NotAllowedError(error.data)
       } else {
         throw new Error("Unknown error")
-
       }
     }
   }


### PR DESCRIPTION
**This PR aims to implement the following:**

The package we are currently using is @codetrix-studio/capacitor-google-auth has few problems. It only exclusively supports Google OAuth and uses APIs that are deprecated.

Specifically, the APIs used for web are not compliant with Google's new authentication system which could lead to problems

While this is only affects the web platform, the package recently went into low maintenance status and encourages to switch to a new package library: cap-go/capacitor-social-login

This PR also fixes the improper session validation.

**Benefits of the new package**
- Supports multiple social logins (Apple, Google, Facebook)

**Breaking changes**
Currently, the library doesn't support the web platform but it is on their roadmap. Considering that AllerTrac will only deploy on Android and iOS devices, this shouldn't be a concerned.

During testing, it is best to login natively with email/password